### PR TITLE
[PD-2906] Removed duplicate MONGO_HOST setting in favor of the MONGO_CN setting.

### DIFF
--- a/base_secrets.py
+++ b/base_secrets.py
@@ -1,7 +1,7 @@
 # Expected contents:
-MONGO_CN = ''  # or MONGO_HOST
+MONGO_CN = ''
 MONGO_DBNAME = ''
 MONGO_SSL = False
 
-TEST_MONGO_HOST = ''  # or TEST_MONGO_CN
+TEST_MONGO_CN = ''
 TEST_MONGO_DBNAME = ''

--- a/pymongoenv/__init__.py
+++ b/pymongoenv/__init__.py
@@ -8,10 +8,7 @@ except ImportError:
     # Provide some meaningless base secrets for compatibility purposes.
     import base_secrets as secrets
 
-if hasattr(secrets, 'MONGO_CN'):
-    mongo_cn = secrets.MONGO_CN
-else:
-    mongo_cn = secrets.MONGO_HOST
+mongo_cn = secrets.MONGO_CN
 mongo_dbname = secrets.MONGO_DBNAME
 mongo_ssl = getattr(secrets, 'MONGO_SSL', False)
 
@@ -30,7 +27,7 @@ def change_db(cn, dbname, ssl_setting):
     mongo_ssl = ssl_setting
 
     secrets.MONGO_SSL = ssl_setting
-    secrets.MONGO_HOST = cn
+    secrets.MONGO_CN = cn
     secrets.MONGO_DBNAME = dbname
 
 
@@ -104,17 +101,11 @@ def db_access(prefix):
     :param prefix: The secrets prefix of the environment you want to access.
 
     """
-    if hasattr(secrets, 'MONGO_CN'):
-        old_host = secrets.MONGO_CN
-    else:
-        old_host = secrets.MONGO_HOST
+    old_host = secrets.MONGO_CN
     old_dbname = secrets.MONGO_DBNAME
     old_ssl = secrets.MONGO_SSL
 
-    if hasattr(secrets, prefix + '_MONGO_CN'):
-        new_cn = getattr(secrets, prefix + '_MONGO_CN')
-    else:
-        new_cn = getattr(secrets, prefix + '_MONGO_HOST')
+    new_cn = getattr(secrets, prefix + '_MONGO_CN')
     new_dbname = getattr(secrets, prefix + '_MONGO_DBNAME')
     new_ssl = getattr(secrets, prefix + '_MONGO_SSL', False)
 

--- a/tests/test_pymongoenv.py
+++ b/tests/test_pymongoenv.py
@@ -36,7 +36,7 @@ class MongoEnvTestCase(TestCase):
         base_secrets aren't carried over between tests.
 
         """
-        set_attrs = ['MONGO_CN', 'MONGO_DBNAME', 'MONGO_SSL', 'MONGO_HOST']
+        set_attrs = ['MONGO_CN', 'MONGO_DBNAME', 'MONGO_SSL']
         for attr in set_attrs:
             if hasattr(base_secrets, attr):
                 delattr(base_secrets, attr)
@@ -68,34 +68,6 @@ class MongoEnvTestCase(TestCase):
         self.assertEqual(pymongoenv.mongo_cn, self.initial_cn)
         self.assertEqual(pymongoenv.mongo_dbname, self.initial_dbname)
         self.assertEqual(pymongoenv.mongo_ssl, self.initial_ssl)
-
-    def test_init_cluster_over_host(self):
-        """
-        When both a mongo host (settings.MONGO_HOST) and a
-        mongo cluster (settings.MONGO_CN) are present, always choose
-        the cluster.
-
-        """
-        mongo_host = 'TEST_HOST'
-        setattr(base_secrets, 'MONGO_HOST', mongo_host)
-
-        pymongoenv = self.import_and_reload_pymongoenv()
-
-        self.assertEqual(pymongoenv.mongo_cn, self.initial_cn)
-
-    def test_init_no_cluster(self):
-        """
-        When a mongo cluster setting (settings.MONGO_CN) isn't present,
-        always fall back to the mongo host (settings.MONGO_HOST) setting.
-
-        """
-        mongo_host = 'TEST_HOST'
-        setattr(base_secrets, 'MONGO_HOST', mongo_host)
-        delattr(base_secrets, 'MONGO_CN')
-
-        pymongoenv = self.import_and_reload_pymongoenv()
-
-        self.assertEqual(pymongoenv.mongo_cn, mongo_host)
 
     def test_change_db_cluster(self):
         """


### PR DESCRIPTION
Remove MONGO_HOST and only use MONGO_CN.

I will still need to go back and update every project that uses this as well as the secrets file. This is just step 1.