### PR TITLE
Test fix

### DIFF
--- a/pymongoenv/__init__.py
+++ b/pymongoenv/__init__.py
@@ -77,6 +77,11 @@ class DbAccess(object):
     def __str__(self):
         return "<DbAccess %r / %r>" % (self.client.host, self.db.name)
 
+    def __del__(self):
+        self.client.close()
+        self.client = None
+        self.db = None
+
 
 @contextmanager
 def production_access():
@@ -123,10 +128,6 @@ def db_access(prefix):
         db_access = connect_db()
         yield db_access
     finally:
-        # Note that this does not protect the db from future operations.
-        db_access.client.close()
-        db_access.client = None
-        db_access.db = None
         change_db(old_host, old_dbname, old_ssl)
 
 

--- a/pymongoenv/tests.py
+++ b/pymongoenv/tests.py
@@ -39,3 +39,4 @@ class MongoTestMixin(object):
     def tearDown(self):
         for collection in self.all_collections:
             collection.delete_many({})
+        del self.db_access

--- a/pymongoenv/tests.py
+++ b/pymongoenv/tests.py
@@ -11,7 +11,7 @@ class MongoTestMixin(object):
     collection_names = []
 
     def setUp(self):
-        change_db(secrets.TEST_MONGO_HOST, secrets.TEST_MONGO_DBNAME,
+        change_db(secrets.TEST_MONGO_CN, secrets.TEST_MONGO_DBNAME,
                   secrets.TEST_MONGO_SSL)
         self.db_access = connect_db()
         self.all_collections = []


### PR DESCRIPTION
Closed the connection in DbAccess rather than the context manager, since we were using DbAccess almost all the time (including the context manager) and the context manager almost never.

No word on why it started acting up now.